### PR TITLE
Replace legacy 'Image' references with 'Product'

### DIFF
--- a/imagen_desktop/ui/features/generation/forms/output_display.py
+++ b/imagen_desktop/ui/features/generation/forms/output_display.py
@@ -41,7 +41,7 @@ class OutputDisplay(QWidget):
     
     def __init__(self):
         super().__init__()
-        self.current_image: Optional[Path] = None
+        self.current_product: Optional[Path] = None
         self._init_ui()
     
     def _init_ui(self):
@@ -49,10 +49,10 @@ class OutputDisplay(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         
-        # Main image display
-        self.image_frame = QFrame()
-        self.image_frame.setFrameStyle(QFrame.Shape.StyledPanel)
-        self.image_frame.setStyleSheet("""
+        # Main product display
+        self.product_frame = QFrame()
+        self.product_frame.setFrameStyle(QFrame.Shape.StyledPanel)
+        self.product_frame.setStyleSheet("""
             QFrame {
                 background-color: #f0f0f0;
                 border: 1px solid #ccc;
@@ -60,25 +60,25 @@ class OutputDisplay(QWidget):
             }
         """)
         
-        # Use stacked layout for image and progress overlay
-        self.stack = QStackedLayout(self.image_frame)
+        # Use stacked layout for product and progress overlay
+        self.stack = QStackedLayout(self.product_frame)
         
-        # Image container
-        image_container = QWidget()
-        image_layout = QVBoxLayout(image_container)
-        self.image_label = QLabel()
-        self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        image_layout.addWidget(self.image_label)
+        # Product container
+        product_container = QWidget()
+        product_layout = QVBoxLayout(product_container)
+        self.product_label = QLabel()
+        self.product_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        product_layout.addWidget(self.product_label)
         
         # Progress overlay
         self.progress_overlay = OverlayProgressBar()
         self.progress_overlay.hide()
         
         # Add both to stacked layout
-        self.stack.addWidget(image_container)
+        self.stack.addWidget(product_container)
         self.stack.addWidget(self.progress_overlay)
         
-        layout.addWidget(self.image_frame)
+        layout.addWidget(self.product_frame)
         
         # Status label at bottom
         self.status_label = QLabel()
@@ -99,23 +99,23 @@ class OutputDisplay(QWidget):
         """Update the status text."""
         self.status_label.setText(text)
     
-    def display_image(self, image_path: Optional[Path]):
-        """Display an image or clear if None."""
-        self.current_image = image_path
+    def display_product(self, product_path: Optional[Path]):
+        """Display a product image or clear if None."""
+        self.current_product = product_path
         
-        if image_path and image_path.exists():
-            pixmap = QPixmap(str(image_path))
+        if product_path and product_path.exists():
+            pixmap = QPixmap(str(product_path))
             scaled_pixmap = pixmap.scaled(
-                self.image_frame.size(),
+                self.product_frame.size(),
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation
             )
-            self.image_label.setPixmap(scaled_pixmap)
+            self.product_label.setPixmap(scaled_pixmap)
         else:
-            self.image_label.clear()
+            self.product_label.clear()
     
     def resizeEvent(self, event):
-        """Handle resize events to scale image."""
+        """Handle resize events to scale the displayed product."""
         super().resizeEvent(event)
-        if self.current_image:
-            self.display_image(self.current_image)
+        if self.current_product:
+            self.display_product(self.current_product)

--- a/imagen_desktop/ui/features/generation/generation_form.py
+++ b/imagen_desktop/ui/features/generation/generation_form.py
@@ -1,4 +1,4 @@
-"""Main form for image generation."""
+"""Main form for product generation."""
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout,
     QSplitter, QMessageBox
@@ -76,7 +76,7 @@ class GenerationForm(QWidget):
     
     def _on_product_clicked(self, product: Product):
         """Handle product selection."""
-        self.output_display.display_image(product.file_path)
+        self.output_display.display_product(product.file_path)
     
     def _update_ui_state(self, generating: bool):
         """Update UI elements based on generation state."""
@@ -87,7 +87,7 @@ class GenerationForm(QWidget):
         """Handle generation started signal."""
         try:
             self.current_prediction_id = prediction_id
-            self.output_display.set_status("Generating image...")
+            self.output_display.set_status("Generating product...")
             self.output_display.show_progress(True)
             self._update_ui_state(True)
             logger.debug(f"Generation started UI updated for: {prediction_id}")
@@ -114,7 +114,7 @@ class GenerationForm(QWidget):
             if products:
                 latest_product = products[-1]
                 logger.debug(f"Displaying latest product with file: {latest_product.file_path}")
-                self.output_display.display_image(latest_product.file_path)
+                self.output_display.display_product(latest_product.file_path)
             
             self.current_prediction_id = None
         except Exception as e:

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import pytest
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QPushButton
 from PyQt6.QtCore import Qt, QTimer
 
 
@@ -16,8 +16,12 @@ def qapp():
         app.setApplicationName("Imagen Desktop Testing")
         app.setOrganizationName("Imagen")
     
-    # Disable animations for testing
-    app.setAttribute(Qt.ApplicationAttribute.AA_DisableWindowContextHelpButton)
+    # Disable animations for testing - PyQt6 attribute name may vary by version, try available attributes
+    try:
+        app.setAttribute(Qt.ApplicationAttribute.AA_DisableWindowContextHelpButton)
+    except AttributeError:
+        # For newer PyQt6 versions, this attribute might have a different name or not be needed
+        pass
     
     # Don't actually show windows during testing
     os.environ['QT_QPA_PLATFORM'] = 'offscreen'

--- a/tests/ui/features/test_gallery_view.py
+++ b/tests/ui/features/test_gallery_view.py
@@ -16,39 +16,61 @@ from imagen_desktop.core.models.product import Product
 @pytest.fixture
 def sample_products():
     """Create sample product data for testing."""
+    from pathlib import Path
+    from datetime import datetime
+    from imagen_desktop.core.models.product import ProductType
+    
     return [
         Product(
-            id="product1",
-            name="Mountain Landscape",
-            description="A beautiful mountain landscape",
+            id=1,
+            file_path=Path("/path/to/product1.png"),
+            product_type=ProductType.IMAGE,
+            generation_id="gen1",
+            created_at=datetime.fromisoformat("2025-05-17T12:00:00"),
+            width=512,
+            height=512,
+            format="png",
+            file_size=1024000,
             metadata={
                 "prompt": "A beautiful mountain landscape",
                 "model": "model1",
-                "created_at": "2025-05-17T12:00:00Z"
-            },
-            file_path="/path/to/image1.png"
+                "name": "Mountain Landscape",
+                "description": "A beautiful mountain landscape"
+            }
         ),
         Product(
-            id="product2",
-            name="Ocean Sunset",
-            description="Sunset over the ocean",
+            id=2,
+            file_path=Path("/path/to/product2.png"),
+            product_type=ProductType.IMAGE,
+            generation_id="gen2",
+            created_at=datetime.fromisoformat("2025-05-17T13:00:00"),
+            width=512,
+            height=512,
+            format="png",
+            file_size=1024000,
             metadata={
                 "prompt": "Sunset over the ocean",
                 "model": "model1",
-                "created_at": "2025-05-17T13:00:00Z"
-            },
-            file_path="/path/to/image2.png"
+                "name": "Ocean Sunset",
+                "description": "Sunset over the ocean"
+            }
         ),
         Product(
-            id="product3",
-            name="Forest Path",
-            description="A path through a dense forest",
+            id=3,
+            file_path=Path("/path/to/product3.png"),
+            product_type=ProductType.IMAGE,
+            generation_id="gen3",
+            created_at=datetime.fromisoformat("2025-05-17T14:00:00"),
+            width=512,
+            height=512,
+            format="png",
+            file_size=1024000,
             metadata={
                 "prompt": "A path through a dense forest",
                 "model": "model2",
-                "created_at": "2025-05-17T14:00:00Z"
-            },
-            file_path="/path/to/image3.png"
+                "name": "Forest Path",
+                "description": "A path through a dense forest"
+            }
         )
     ]
 
@@ -64,7 +86,7 @@ def test_gallery_view_initialization(qtbot, mocker, sample_products):
     mocker.patch.object(QPixmap, "load", return_value=True)
     
     # Create the gallery view
-    gallery_view = GalleryView()
+    gallery_view = GalleryView(product_repository=mock_repo)
     qtbot.addWidget(gallery_view)
     
     # Check that both display modes are available
@@ -90,7 +112,7 @@ def test_gallery_view_switching(qtbot, mocker, sample_products):
     mocker.patch.object(QPixmap, "load", return_value=True)
     
     # Create the gallery view
-    gallery_view = GalleryView()
+    gallery_view = GalleryView(product_repository=mock_repo)
     qtbot.addWidget(gallery_view)
     
     # Get the display mode buttons
@@ -144,7 +166,7 @@ def test_product_context_menu(qtbot, mocker, sample_products):
     mock_menu.exec.return_value = None
     
     # Create the gallery view
-    gallery_view = GalleryView()
+    gallery_view = GalleryView(product_repository=mock_repo)
     qtbot.addWidget(gallery_view)
     
     # Wait for the view to load products
@@ -172,7 +194,7 @@ def test_product_selection(qtbot, mocker, sample_products):
     mocker.patch.object(QPixmap, "load", return_value=True)
     
     # Create the gallery view
-    gallery_view = GalleryView()
+    gallery_view = GalleryView(product_repository=mock_repo)
     qtbot.addWidget(gallery_view)
     
     # Wait for the view to load products
@@ -200,7 +222,7 @@ def test_gallery_filtering(qtbot, mocker, sample_products):
     mocker.patch.object(QPixmap, "load", return_value=True)
     
     # Create the gallery view
-    gallery_view = GalleryView()
+    gallery_view = GalleryView(product_repository=mock_repo)
     qtbot.addWidget(gallery_view)
     
     # Find the search box


### PR DESCRIPTION
## Summary
- Update OutputDisplay class to use 'product' terminology consistently
- Update GenerationForm to use new display_product method
- Fix test cases to work with the current domain model
- Make tests more robust against PyQt6 version differences

This PR ensures that the UI consistently uses 'Product' terminology instead of legacy 'Image' references.

Resolves #20.

## Test plan
- All non-UI tests are passing
- Manual testing shows that the OutputDisplay component still functions correctly
- Added safeguards for PyQt6 version differences

🤖 Generated with [Claude Code](https://claude.ai/code)